### PR TITLE
chore(Gradle): implement build-logic convention plugins

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,51 +1,10 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.compose)
-}
-
-android {
-    namespace = "com.uliteamr.notescribe"
-    compileSdk {
-        version = release(36) {
-            minorApiLevel = 1
-        }
-    }
-
-    defaultConfig {
-        applicationId = "com.uliteamr.notescribe"
-        minSdk = 26
-        targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    buildFeatures {
-        compose = true
-    }
+    id("notescribe.android.application")
+    id("notescribe.compose")
 }
 
 dependencies {
-    implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.graphics)
-    implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     testImplementation(libs.junit)
@@ -53,6 +12,4 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.junit)
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
-    debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -22,5 +22,5 @@ gradlePlugin {
 dependencies {
     implementation(libs.android.gradle)
     implementation(libs.kotlin.gradle)
-    implementation("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:2.2.10")
+    implementation(libs.kotlin.compose.gradle)
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    `kotlin-dsl`
+}
+
+gradlePlugin {
+    plugins {
+        register("androidApplication") {
+            id = "notescribe.android.application"
+            implementationClass = "com.uliteamr.notescribe.buildlogic.AndroidApplicationConventionPlugin"
+        }
+        register("androidLibrary") {
+            id = "notescribe.android.library"
+            implementationClass = "com.uliteamr.notescribe.buildlogic.AndroidLibraryConventionPlugin"
+        }
+        register("compose") {
+            id = "notescribe.compose"
+            implementationClass = "com.uliteamr.notescribe.buildlogic.ComposeConventionPlugin"
+        }
+    }
+}
+
+dependencies {
+    implementation(libs.android.gradle)
+    implementation(libs.kotlin.gradle)
+    implementation("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:2.2.10")
+}

--- a/build-logic/gradle/libs.versions.toml
+++ b/build-logic/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+agp = "9.2.1"
+kotlin = "2.2.10"
+
+[libraries]
+android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/build-logic/gradle/libs.versions.toml
+++ b/build-logic/gradle/libs.versions.toml
@@ -1,7 +1,0 @@
-[versions]
-agp = "9.2.1"
-kotlin = "2.2.10"
-
-[libraries]
-android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,8 @@
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "build-logic"

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -3,6 +3,11 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
     }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }
 
 rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/AndroidApplicationConventionPlugin.kt
@@ -1,6 +1,7 @@
 package com.uliteamr.notescribe.buildlogic
 
 import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -106,15 +107,26 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                         }
                         val propFile = File(propPath)
                         if (propFile.exists()) {
-                            val properties = Properties().also { it.load(propFile.inputStream()) }
-                            keyAlias = properties.getProperty("keyAlias")
-                            keyPassword = properties.getProperty("keyPassword")
+                            val properties = Properties()
+                            propFile.inputStream().use { properties.load(it) }
+                            keyAlias = properties.getProperty("keyAlias").also {
+                                if (it.isNullOrBlank()) throw GradleException("keyAlias is missing in $propPath")
+                            }
+                            keyPassword = properties.getProperty("keyPassword").also {
+                                if (it.isNullOrBlank()) throw GradleException("keyPassword is missing in $propPath")
+                            }
                             storeFile = if (isCI) {
                                 File("/tmp/release.keystore")
                             } else {
-                                File(properties.getProperty("storeFile"))
+                                val path = properties.getProperty("storeFile")
+                                if (path.isNullOrBlank()) throw GradleException("storeFile is missing in $propPath")
+                                val file = File(path)
+                                if (!file.exists() || !file.canRead()) throw GradleException("storeFile not found or not readable: $path")
+                                file
                             }
-                            storePassword = properties.getProperty("storePassword")
+                            storePassword = properties.getProperty("storePassword").also {
+                                if (it.isNullOrBlank()) throw GradleException("storePassword is missing in $propPath")
+                            }
                         } else {
                             println("Sign properties not found at $propPath — release signing will fail if required.")
                         }

--- a/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/AndroidApplicationConventionPlugin.kt
@@ -1,0 +1,152 @@
+package com.uliteamr.notescribe.buildlogic
+
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import java.io.File
+import java.util.Properties
+
+/**
+ * Pre-configured convention plugin for Android application modules.
+ *
+ * Applies the Android application plugin and configures:
+ * - Common Android settings (SDK versions, Java 21) via [configureAndroidDefaults].
+ * - Application-specific metadata (namespace, applicationId, targetSdk).
+ * - Versioning (versionCode, versionName) from [NoteScribeConfig].
+ * - Automated release signing using `~/.sign/sign.properties` (or `/tmp/sign.properties` in CI).
+ * - Debug signing using `keystore/debug.keystore`.
+ * - Product flavors for ABI architectures (universal, arm64, armeabi, x86, x86_64).
+ * - Release and debug build types with appropriate defaults.
+ *
+ * Usage in a module's build.gradle.kts:
+ * ```
+ * plugins {
+ *     id("notescribe.android.application")
+ * }
+ * ```
+ */
+class AndroidApplicationConventionPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.android.application")
+
+            extensions.configure<ApplicationExtension> {
+                configureAndroidDefaults()
+
+                buildFeatures {
+                    buildConfig = true
+                    compose = true
+                }
+
+                namespace = NoteScribeConfig.GROUP
+
+                defaultConfig {
+                    applicationId = NoteScribeConfig.GROUP
+                    minSdk = NoteScribeConfig.MIN_SDK
+                    targetSdk = NoteScribeConfig.TARGET_SDK
+                    versionCode = NoteScribeConfig.VERSION_CODE
+                    versionName = NoteScribeConfig.versionName(suffix = "Alpha", iteration = 1)
+                }
+
+                flavorDimensions += "abi"
+
+                productFlavors {
+                    create("universal") {
+                        dimension = "abi"
+                        buildConfigField("String", "ARCHITECTURE", "\"universal\"")
+                    }
+
+                    create("arm64") {
+                        dimension = "abi"
+                        ndk {
+                            abiFilters.clear()
+                            abiFilters.add("arm64-v8a")
+                        }
+                        buildConfigField("String", "ARCHITECTURE", "\"arm64-v8a\"")
+                    }
+
+                    create("armeabi") {
+                        dimension = "abi"
+                        ndk {
+                            abiFilters.clear()
+                            abiFilters.add("armeabi-v7a")
+                        }
+                        buildConfigField("String", "ARCHITECTURE", "\"armeabi-v7a\"")
+                    }
+
+                    create("x86") {
+                        dimension = "abi"
+                        ndk {
+                            abiFilters.clear()
+                            abiFilters.add("x86")
+                        }
+                        buildConfigField("String", "ARCHITECTURE", "\"x86\"")
+                    }
+
+                    create("x86_64") {
+                        dimension = "abi"
+                        ndk {
+                            abiFilters.clear()
+                            abiFilters.add("x86_64")
+                        }
+                        buildConfigField("String", "ARCHITECTURE", "\"x86_64\"")
+                    }
+                }
+
+                signingConfigs {
+                    // Based on klyx-dev/klyx (https://github.com/klyx-dev/klyx) by Vivek
+                    create("release") {
+                        val isCI = System.getenv("GITHUB_ACTIONS")?.toBoolean() ?: false
+                        val propPath = if (isCI) {
+                            "/tmp/sign.properties"
+                        } else {
+                            File(System.getProperty("user.home"), ".sign/sign.properties").absolutePath
+                        }
+                        val propFile = File(propPath)
+                        if (propFile.exists()) {
+                            val properties = Properties().also { it.load(propFile.inputStream()) }
+                            keyAlias = properties.getProperty("keyAlias")
+                            keyPassword = properties.getProperty("keyPassword")
+                            storeFile = if (isCI) {
+                                File("/tmp/release.keystore")
+                            } else {
+                                File(properties.getProperty("storeFile"))
+                            }
+                            storePassword = properties.getProperty("storePassword")
+                        } else {
+                            println("Sign properties not found at $propPath — release signing will fail if required.")
+                        }
+                    }
+
+                    create("debugkey") {
+                        keyAlias = "debug"
+                        keyPassword = "debugpass"
+                        storeFile = file("keystore/debug.keystore")
+                        storePassword = "debugpass"
+                    }
+                }
+
+                buildTypes {
+                    getByName("release") {
+                        isMinifyEnabled = true
+                        isShrinkResources = true
+                        proguardFiles(
+                            getDefaultProguardFile("proguard-android-optimize.txt"),
+                            "proguard-rules.pro"
+                        )
+                        signingConfig = signingConfigs.getByName("release")
+                    }
+
+                    getByName("debug") {
+                        applicationIdSuffix = ".debug"
+                        versionNameSuffix = "-DEBUG"
+                        isDebuggable = true
+                        signingConfig = signingConfigs.getByName("debugkey")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/AndroidDefaults.kt
+++ b/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/AndroidDefaults.kt
@@ -1,0 +1,23 @@
+package com.uliteamr.notescribe.buildlogic
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
+
+/**
+ * Applies common Android SDK and Java configuration from [NoteScribeConfig].
+ *
+ * Handles properties available on [CommonExtension] that are identical
+ * for both application and library modules:
+ * - [CommonExtension.compileSdk]
+ * - [CommonExtension.compileOptions]
+ *
+ * Module-specific configuration (defaultConfig, buildFeatures) is handled
+ * individually in [AndroidApplicationConventionPlugin] and
+ * [AndroidLibraryConventionPlugin].
+ */
+internal fun CommonExtension.configureAndroidDefaults() {
+    compileSdk = NoteScribeConfig.COMPILE_SDK
+
+    compileOptions.sourceCompatibility = JavaVersion.VERSION_21
+    compileOptions.targetCompatibility = JavaVersion.VERSION_21
+}

--- a/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/AndroidLibraryConventionPlugin.kt
@@ -1,0 +1,45 @@
+package com.uliteamr.notescribe.buildlogic
+
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * Pre-configured convention plugin for Android library modules.
+ *
+ * Applies the Android library plugin and configures the
+ * [LibraryExtension] using [NoteScribeConfig] constants.
+ * This is intended for shared or feature modules.
+ *
+ * Usage in a module's build.gradle.kts:
+ * ```
+ * plugins {
+ *     id("notescribe.android.library")
+ * }
+ * ```
+ */
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("com.android.library")
+            }
+
+            configure<LibraryExtension> {
+                configureAndroidDefaults()
+
+                buildFeatures {
+                    compose = true
+                }
+
+                namespace = NoteScribeConfig.SHARED_NAMESPACE
+
+                defaultConfig {
+                    minSdk = NoteScribeConfig.MIN_SDK
+                }
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/ComposeConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/ComposeConventionPlugin.kt
@@ -2,6 +2,7 @@ package com.uliteamr.notescribe.buildlogic
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.dependencies
 
 /**
@@ -23,15 +24,19 @@ class ComposeConventionPlugin : Plugin<Project> {
         with(target) {
             pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
 
+            val libs = rootProject.extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
+
             dependencies {
-                add("implementation", platform("androidx.compose:compose-bom:2026.02.01"))
+                val bom = libs.findLibrary("androidx-compose-bom").get()
+                add("implementation", platform(bom))
                 add("implementation", "androidx.compose.ui:ui")
                 add("implementation", "androidx.compose.ui:ui-graphics")
                 add("implementation", "androidx.compose.ui:ui-tooling-preview")
                 add("implementation", "androidx.compose.material3:material3")
                 add("debugImplementation", "androidx.compose.ui:ui-tooling")
                 add("debugImplementation", "androidx.compose.ui:ui-test-manifest")
-                add("implementation", "androidx.navigation:navigation-compose:2.9.8")
+                val navCompose = libs.findLibrary("androidx-navigation-compose").get()
+                add("implementation", navCompose)
             }
         }
     }

--- a/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/ComposeConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/ComposeConventionPlugin.kt
@@ -1,0 +1,38 @@
+package com.uliteamr.notescribe.buildlogic
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+/**
+ * Convention plugin that configures Jetpack Compose for a module.
+ *
+ * Applies the Kotlin Compose compiler plugin and adds the standard
+ * Compose BOM and UI dependencies to the module's classpath.
+ *
+ * Usage in a module's build.gradle.kts:
+ * ```
+ * plugins {
+ *     id("notescribe.compose")
+ * }
+ * ```
+ */
+class ComposeConventionPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
+
+            dependencies {
+                add("implementation", platform("androidx.compose:compose-bom:2026.02.01"))
+                add("implementation", "androidx.compose.ui:ui")
+                add("implementation", "androidx.compose.ui:ui-graphics")
+                add("implementation", "androidx.compose.ui:ui-tooling-preview")
+                add("implementation", "androidx.compose.material3:material3")
+                add("debugImplementation", "androidx.compose.ui:ui-tooling")
+                add("debugImplementation", "androidx.compose.ui:ui-test-manifest")
+                add("implementation", "androidx.navigation:navigation-compose:2.9.8")
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/NoteScribeConfig.kt
+++ b/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/NoteScribeConfig.kt
@@ -52,8 +52,8 @@ object NoteScribeConfig {
      * Generates a semantic version name string based on the current version constants.
      *
      * Example outputs:
-     * - Default: "1.0.0"
-     * - With suffix: "1.0.0-alpha01"
+     * - Default: "0.1.0"
+     * - With suffix: "0.1.0-alpha01"
      *
      * @param major The major version number. Defaults to [MAJOR].
      * @param minor The minor version number. Defaults to [MINOR].

--- a/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/NoteScribeConfig.kt
+++ b/build-logic/src/main/kotlin/com/uliteamr/notescribe/buildlogic/NoteScribeConfig.kt
@@ -1,0 +1,79 @@
+package com.uliteamr.notescribe.buildlogic
+
+/**
+ * Centralized configuration constants for the NoteScribe project.
+ *
+ * All modules should reference this object for versioning, SDK levels,
+ * and shared namespaces to maintain a single source of truth.
+ */
+object NoteScribeConfig {
+
+    /**
+     * The base group identifier for the project.
+     * Used as the default namespace and applicationId prefix.
+     */
+    const val GROUP = "com.uliteamr.notescribe"
+
+    /**
+     * Common namespace for shared/library modules.
+     */
+    const val SHARED_NAMESPACE = "$GROUP.shared"
+
+    // --- SDK Level Constants ---
+
+    /**
+     * The compile SDK version for all Android modules.
+     */
+    const val COMPILE_SDK = 36
+
+    /**
+     * The minimum SDK version supported by the application.
+     */
+    const val MIN_SDK = 26
+
+    /**
+     * The target SDK version for the application.
+     */
+    const val TARGET_SDK = 36
+
+    // --- Versioning Constants ---
+
+    private const val MAJOR = 0
+    private const val MINOR = 1
+    private const val PATCH = 0
+
+    /**
+     * The numeric version code for the Android application.
+     * Increment this for every new release to the Play Store.
+     */
+    const val VERSION_CODE = 1
+
+    /**
+     * Generates a semantic version name string based on the current version constants.
+     *
+     * Example outputs:
+     * - Default: "1.0.0"
+     * - With suffix: "1.0.0-alpha01"
+     *
+     * @param major The major version number. Defaults to [MAJOR].
+     * @param minor The minor version number. Defaults to [MINOR].
+     * @param patch The patch version number. Defaults to [PATCH].
+     * @param suffix An optional suffix string (e.g., "alpha", "beta", "rc").
+     * @param iteration The iteration number for the suffix. If greater than 0, it is zero-padded.
+     * @return A formatted semantic version name string.
+     */
+    fun versionName(
+        major: Int = MAJOR,
+        minor: Int = MINOR,
+        patch: Int = PATCH,
+        suffix: String = "",
+        iteration: Int = 0
+    ): String {
+        val base = "$major.$minor.$patch"
+
+        if (suffix.isBlank()) return base
+
+        val iterationStr = if (iteration > 0) iteration.toString().padStart(2, '0') else ""
+        return "$base-$suffix$iterationStr"
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,1 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-plugins {
-    alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.compose) apply false
-}
+plugins {}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,12 +6,14 @@ junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
-kotlin = "2.2.10"
-composeBom = "2026.02.01"
+kotlin = "2.3.21"
+composeBom = "2026.05.01"
+navigationCompose = "2.9.8"
 
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-compose-gradle = { module = "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin", version.ref = "kotlin" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
@@ -26,6 +28,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ kotlin = "2.2.10"
 composeBom = "2026.02.01"
 
 [libraries]
+android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,3 +24,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "NoteScribe"
 include(":app")
+
+includeBuild("build-logic")


### PR DESCRIPTION
## Summary
Extract Gradle configuration into a `build-logic` included build with reusable convention plugins, replacing inline module boilerplate with a single source of truth.
---
## Motivation
Previously, each module duplicated Android SDK settings, signing configs, Compose dependencies, and build type definitions. This made version bumps error-prone and adding new modules tedious. The build-logic convention plugin pattern (inspired by [Now in Android](https://github.com/android/nowinandroid)) centralises all configuration into composable, testable plugins.
---
## What was done
### 1. New `build-logic/` included build
| File | Purpose |
|---|---|
| `build-logic/settings.gradle.kts` | Declares repositories and sets the build name. |
| `build-logic/build.gradle.kts` | Registers three convention plugins via `gradlePlugin {}`; pulls in AGP, Kotlin Gradle Plugin, and the Compose compiler plugin as implementation dependencies. |
| `build-logic/gradle/libs.versions.toml` | Version catalog for AGP and Kotlin used internally by build-logic. |
### 2. Convention plugins (`build-logic/src/main/kotlin/…/buildlogic/`)
**`NoteScribeConfig.kt`** – Single source of truth for:
- `GROUP` → `com.uliteamr.notescribe`
- SDK levels: `compileSdk = 36`, `minSdk = 26`, `targetSdk = 36`
- Versioning: `VERSION_CODE = 1`, `versionName()` with optional suffix/iteration
- Replaces scattered hardcoded values across all modules.
**`AndroidDefaults.kt`** – Internal extension function `CommonExtension.configureAndroidDefaults()` that sets `compileSdk` and Java 21 source/target compatibility, shared by both application and library plugins.
**`AndroidApplicationConventionPlugin`** – Applied via `id("notescribe.android.application")`:
- Applies `com.android.application`.
- Configures `namespace`, `applicationId`, `versionCode`, `versionName`.
- Enables `buildConfig` and Compose.
- Defines **5 ABI product flavors** (`universal`, `arm64`, `armeabi`, `x86`, `x86_64`).
- Sets up **release signing** from `~/.sign/sign.properties` (local) or `/tmp/sign.properties` (CI) — credit to [klyx-dev/klyx](https://github.com/klyx-dev/klyx).
- Sets up **debug signing** from `keystore/debug.keystore`.
- Configures release (minify + ProGuard) and debug (`.debug` suffix, debuggable) build types.
**`AndroidLibraryConventionPlugin`** – Applied via `id("notescribe.android.library")`:
- Applies `com.android.library`.
- Uses `NoteScribeConfig.SHARED_NAMESPACE` and `minSdk`.
- Enables Compose.
**`ComposeConventionPlugin`** – Applied via `id("notescribe.compose")`:
- Applies `org.jetbrains.kotlin.plugin.compose`.
- Adds Compose BOM (`2026.02.01`), Material3, UI, Navigation Compose, and debug-only tooling/test dependencies.
### 3. Updated existing files
| File | Change |
|---|---|
| `settings.gradle.kts` | Added `includeBuild("build-logic")` so convention plugins are resolvable. |
| `build.gradle.kts` (root) | Removed plugin aliases — convention plugins resolve transitively. |
| `app/build.gradle.kts` | Reduced from ~58 lines of inline Android config to 10 lines — delegates to `notescribe.android.application` and `notescribe.compose`. |
| `gradle/libs.versions.toml` | Added `android-gradle` and `kotlin-gradle` library entries used by the root project. |
---
## How to use
```kotlin
// For an app module
plugins {
    id("notescribe.android.application")
    id("notescribe.compose")
}
// For a library module
plugins {
    id("notescribe.android.library")
    id("notescribe.compose")
}
Configuration constants (SDK, versions) are edited once in NoteScribeConfig.kt and propagate automatically.
Checklist
- Build-logic compiles successfully
- :app:assembleDebug produces APKs for all ABI flavors
- Debug signing works via generated debug keystore
- ProGuard rules are preserved
- Release signing tested in CI environment (requires GITHUB_ACTIONS set and /tmp/sign.properties)
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kotlin compiler to version 2.3.21
  * Updated Compose BOM to version 2026.05.01
  * Added navigation compose support

* **Refactor**
  * Restructured build configuration system for improved maintainability
  * Consolidated dependency and version management across modules
  * Centralized project configuration settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ulite-Amr/NoteScribe/pull/1?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->